### PR TITLE
-Fixed pathing when using windows as host environment

### DIFF
--- a/src/phpunit.ts
+++ b/src/phpunit.ts
@@ -41,7 +41,7 @@ export class PhpUnit {
         let document = editor.document
 
         if (document && !document.isUntitled && document.uri && document.uri.fsPath.endsWith('.php')) {
-          let docPath = document.uri.fsPath
+          let docPath = document.uri.path
           let data = resolvePathOnly ? path.dirname(docPath) : docPath
 
           result = that.convertLocalPathToContainerPath(data)


### PR DESCRIPTION
Since convertLocalPathToContainerPath is using the "path" as opposed to "fsPath" like in convertDocumentPathToContainerResource , I figured both should be using "path". This fixes the issue met when having a windows host with a linux docker container. 